### PR TITLE
2022-10-22: fixed error with scan_result && added requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+btrfsutil==5.18.1
+configobj==5.1.0.dev0
+distlib==0.3.6
+filelock==3.8.0
+lit==14.0.6.dev0
+platformdirs==2.5.2
+psutil==5.9.1
+pycairo==1.21.0
+PyGObject==3.42.2
+Reflector==2021.11.20.2.41.3
+six==1.16.0
+terminator==2.1.1
+validate==5.1.0.dev0
+virtualenv==20.16.5

--- a/sshprank.py
+++ b/sshprank.py
@@ -352,9 +352,15 @@ def grab_banner(host, port):
   return
 
 
+class PortScanner(masscan.PortScanner):
+    @property
+    def scan_result(self):
+        return self._scan_result
+
+
 def portscan():
   try:
-    m = masscan.PortScanner()
+    m = PortScanner()
     m.scan(hosts='', ports='0', arguments=opts['masscan_opts'], sudo=True)
   except masscan.NetworkConnectionError as err:
     log('\n')
@@ -369,11 +375,19 @@ def portscan():
 def grep_service(scan, service='ssh', prot='tcp'):
   targets = []
 
-  for h in scan.scan_result['scan'].keys():
-    for p in scan.scan_result['scan'][h][prot]:
-      if scan.scan_result['scan'][h][prot][p]['state'] == 'open':
-        if scan.scan_result['scan'][h][prot][p]['services']:
-          for s in scan.scan_result['scan'][h][prot][p]['services']:
+  '''
+  import json
+  print(scan, type(scan))
+  print(scan.scan_result, type(scan.scan_result))
+  scan_result = json.loads(scan.scan_result)
+  '''
+
+  scan_result = scan.scan_result
+  for h in scan_result['scan'].keys():
+    for p in scan_result['scan'][h][prot]:
+      if scan_result['scan'][h][prot][p]['state'] == 'open':
+        if scan_result['scan'][h][prot][p]['services']:
+          for s in scan_result['scan'][h][prot][p]['services']:
             target = f"{h}:{str(p)}:{s['banner']}\n"
             if opts['verbose']:
               log(f'found sshd: {target}', 'good', esc='')


### PR DESCRIPTION
The error was due to `scan_result.scan` being a string instead of a dict. The `scan_result` property of `masscan.PortScanner` returns the serialized dict as string ( `json.dumps` ).